### PR TITLE
begin listening for the bridge ready event as soon as possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Pulsar Javascript API Examples
 
 This repository contains canonical example code of the HTML/CSS/Javascript interaction with the Pulsar App.
 
+### `pulsar-js-bridge.html`
+
+This file contains a minimal example that demonstrates how to setup the Pulsar JS bridge from within any context in the Pulsar App. There are two <script> blocks in the header. The first contains all the code required to prepare the bridge for your application. The second is a minimal example of how to start an application. The connecting bit of code between these two in this particular case is the function startApp(). This is defined in second <script> block, and called in the first. You can rename this function, but make sure that you modify the function calls in the first block of code to reflect any naming changes.
+
 ### `hello.html`
 
 A simple, self-contained, "hello world" example that exercises the Pulsar Javascript API.  Performs some simple queries and prints out the results.

--- a/hello.html
+++ b/hello.html
@@ -107,13 +107,14 @@
        * ******************************/
       const runningEmbedded = (window.top !== window.self);
       window.onload = function() {
-
+        var inFSL = false;
+        var standAlone = false;
         if (runningEmbedded && window.parent.pulsar && window.parent.pulsar.bridge) {
           /* ************************************************************
-           * If the above is true, we are running in an embedded state
-           * within the Pulsar for FSL app. In this case, the above
-           * registered event listener will never fire as the webview we
-           * are running in already has established a Pulsar JS bridge.
+           * If the above is true, we are running in an embedded state.
+           * In this case, the above registered event listener will never
+           * fire as the webview we are running in already has
+           * established a Pulsar JS bridge.
            * ************************************************************/
           window.pulsar = window.parent.pulsar; // ensure we will pass down the embedded window.pulsar
           console.assert(window.pulsar.bridge !== undefined);
@@ -138,8 +139,12 @@
              * webview context. The Pulsar JS bridge will be established by
              * the event listener above. So we do nothing here.
              * ************************************************************/
+             standAlone = true;
           }
         }
+        console.assert(!(runningEmbedded && standAlone));
+        console.assert(runningEmbedded || standAlone);
+        console.log('Starting App' + (runningEmbedded ? ' embedded' : '') + (inFSL ? ' in FSL' : '') + (standAlone ? ' stand alone' : ''));
       };
       /* ******************************
        * END Pulsar onload definition
@@ -147,6 +152,20 @@
     </script>
 
     <script type="text/javascript">
+
+    /**
+     * Helper function to determine whether we are in an FSL or stand-alone
+     * context.
+     **/
+    function getApplicationStatus() {
+
+      if (runningEmbedded && window.parent.pulsar && window.parent.pulsar.bridge) {
+        // FSL toplevel app sets additional methods you can use
+        inFSL = (window.pulsar['displayContentDocument'] !== undefined);
+      } else {
+        standAlone = true;
+      }
+    }
 
     /**
      * Helper function to extract URL query variables
@@ -195,6 +214,9 @@
         var refObjectId = undefined;
 
         function startApp() {
+
+            getApplicationStatus();
+
             // if launched from a record, this is the object Id in question
             refObjectId = getQueryVariable('ref_id');
 

--- a/hello.html
+++ b/hello.html
@@ -7,83 +7,146 @@
     <title>Pulsar JS Hello World</title>
 
     <script type="text/javascript">
+      /* *********************************
+       * Prepare for bridge initialization
+       * *********************************/
 
-    /* ******************************
-     * BEGIN Pulsar bridge definition
-     * ******************************/
+      /* Launched from an unembedded state, startApp() fires on the bridge ready event. */
+      document.addEventListener('WebViewJavascriptBridgeReady', function(event) {
+        bridge.init(event.bridge);
 
-        var BRIDGE_ON = true; // set to false to test file in desktop browser
+        /* Note: If we are receiving this event, window.pulsar is undefined */
+        window.pulsar = {};
+        window.pulsar.bridge = event.bridge; // save initial bridge (for propagation to other pages)
 
-        var bridge = function() {
+        /* !!!! IMPORTANT !!!!
+         * The bridge has been initialized and your app is ready for launch.
+         * startApp() is any arbitrary method that a developer may define
+         * to start their application using the Pulsar JS bridge.
+         */
+        startApp();
+      }, false);
 
-            var jsbridge;
-            var _bridge = {};
+      /* ******************************
+       * BEGIN Pulsar bridge definition
+       * ******************************/
+      var BRIDGE_ON = true; // set to false to test file in desktop browser
 
-            /** **************************************************************
-             *  Sends a request (object containing type,
-             *  object, and data properties) across the JS Bridge,
-             *  and results are delivered to the callback function
-             *  @param {object} request data
-             *  @param {function} callback result function (called asynchronously)
-             * ***************************************************************/
-            _bridge.sendRequest = function(request, callbackFn) {
-                try {
-                    if (BRIDGE_ON) {
-                        jsbridge.send(request, callbackFn);
-                    } else {
-                        callbackFn({});
-                    }
-                } catch (err) {
-                    alert('Javascript-App bridge error: ' + err);
-                }
-            };
+      var bridge = function() {
 
-            /** **************************************************************
-             * Add a handler for a particular notification
-             * @param {string} handlerName name of notification
-             * @param {function} handlerFn function called for notification
-             * ***************************************************************/
-            _bridge.addHandler = function(handlerName, handlerFn) {
-                jsbridge.registerHandler(handlerName, handlerFn);
-            };
+        var jsbridge;
+        var _bridge = {};
 
-            /** **************************************************************
-             * Remove handler for a particular notification
-             * @param {string} handlerName name of notification
-             * ***************************************************************/
-            _bridge.removeHandler = function(handlerName) {
-                jsbridge.deregisterHandler(handlerName);
-            };
-
-            /** **************************************************************
-             * Initializes the JS Bridge.
-             * This should only be called once.
-             * @param {WebViewJavascriptBridge} _jsbridge the bridge
-             * ***************************************************************/
-            _bridge.init = function(_jsbridge) {
-                if (BRIDGE_ON) {
-                    _jsbridge.init(function(message, responseCallback) {
-                        console.log('Received message: ' + message);
-                    });
-
-                    jsbridge = _jsbridge;
-                }
-            };
-
-            /** **************************************************************
-             * Sets up JS Bridge without reinitializing.
-             * @param {WebViewJavascriptBridge} _jsbridge the bridge
-             * ***************************************************************/
-            _bridge.setup = function(_jsbridge) {
-                jsbridge = _jsbridge;
+        /** **************************************************************
+         *  Sends a request (object containing type,
+         *  object, and data properties) across the JS Bridge,
+         *  and results are delivered to the callback function
+         *  @param {object} request data
+         *  @param {function} callback result function (called asynchronously)
+         * ***************************************************************/
+        _bridge.sendRequest = function(request, callbackFn) {
+          try {
+            if (BRIDGE_ON) {
+              jsbridge.send(request, callbackFn);
+            } else {
+              callbackFn({});
             }
+          } catch (err) {
+            alert('Javascript-App bridge error: ' + err);
+          }
+        };
 
-            return _bridge;
-        }();
+        /** **************************************************************
+         * Add a handler for a particular notification
+         * @param {string} handlerName name of notification
+         * @param {function} handlerFn function called for notification
+         * ***************************************************************/
+        _bridge.addHandler = function(handlerName, handlerFn) {
+          jsbridge.registerHandler(handlerName, handlerFn);
+        };
 
-    /* ******************************
-     *  END Pulsar bridge definition
-     * ******************************/
+        /** **************************************************************
+         * Remove handler for a particular notification
+         * @param {string} handlerName name of notification
+         * ***************************************************************/
+        _bridge.removeHandler = function(handlerName) {
+          jsbridge.deregisterHandler(handlerName);
+        };
+
+        /** **************************************************************
+         * Initializes the JS Bridge.
+         * This should only be called once.
+         * @param {WebViewJavascriptBridge} _jsbridge the bridge
+         * ***************************************************************/
+        _bridge.init = function(_jsbridge) {
+          if (BRIDGE_ON) {
+            _jsbridge.init(function(message, responseCallback) {
+              console.log('Received message: ' + message);
+            });
+
+            jsbridge = _jsbridge;
+          }
+        };
+
+        /** **************************************************************
+         * Sets up JS Bridge without reinitializing.
+         * @param {WebViewJavascriptBridge} _jsbridge the bridge
+         * ***************************************************************/
+        _bridge.setup = function(_jsbridge) {
+          jsbridge = _jsbridge;
+        }
+
+        return _bridge;
+      }();
+      /* ******************************
+       *  END Pulsar bridge definition
+       * ******************************/
+
+      /* ******************************
+       * BEGIN Pulsar onload definition
+       * ******************************/
+      const runningEmbedded = (window.top !== window.self);
+      window.onload = function() {
+
+        if (runningEmbedded && window.parent.pulsar && window.parent.pulsar.bridge) {
+          /* ************************************************************
+           * If the above is true, we are running in an embedded state
+           * within the Pulsar for FSL app. In this case, the above
+           * registered event listener will never fire as the webview we
+           * are running in already has established a Pulsar JS bridge.
+           * ************************************************************/
+          window.pulsar = window.parent.pulsar; // ensure we will pass down the embedded window.pulsar
+          console.assert(window.pulsar.bridge !== undefined);
+          bridge.setup(window.pulsar.bridge);
+
+          /* At this point we have the correct Pulsar JS Bridge object from the window itself.
+           * Start your app! */
+          startApp();
+
+        } else {
+          if (runningEmbedded) {
+            /* ************************************************************
+             * Something has gone wrong if we are running embedded and find
+             * ourselves without a window.parent.pulsar.bridge or
+             * window.parent.pulsar object.
+             * ************************************************************/
+            console.log('OOPS, running embedded, but no window.parent.pulsar.bridge!');
+            throw 'embedded misconfiguration!';
+          } else {
+            /* ************************************************************
+             * Otherwise we are running in a stand-alone state in our own
+             * webview context. The Pulsar JS bridge will be established by
+             * the event listener above. So we do nothing here.
+             * ************************************************************/
+          }
+        }
+      };
+      /* ******************************
+       * END Pulsar onload definition
+       * ******************************/
+    </script>
+
+    <script type="text/javascript">
 
     /**
      * Helper function to extract URL query variables
@@ -130,39 +193,6 @@
         // example variables set during startup
         var platform = 'unknown';
         var refObjectId = undefined;
-
-        window.onload = function () {
-            let inFSL = false;
-            let standAlone = false;
-            const runningEmbedded = (window.top !== window.self);
-
-            if (runningEmbedded && window.parent.pulsar && window.parent.pulsar.bridge) {
-                window.pulsar = window.parent.pulsar; // ensure we will pass down the embedded window.pulsar
-                console.assert(window.pulsar.bridge !== undefined)
-                inFSL = (window.pulsar['displayContentDocument'] !== undefined); // FSL toplevel app sets additional methods you can use
-                bridge.setup(window.pulsar.bridge);
-                startApp();
-            }
-            else {
-                if (runningEmbedded) {
-                    console.log('OOPS, running embedded, but no window.parent.pulsar.bridge!');
-                    throw 'embedded misconfiguration!';
-                }
-                standAlone = true;
-
-                // Launched stand-alone, startApp() on the bridge ready event
-                document.addEventListener('WebViewJavascriptBridgeReady', function(event) {
-                    bridge.init(event.bridge);
-                    window.pulsar = {};
-                    window.pulsar.bridge = event.bridge; // save initial bridge (for propagation to other pages)
-                    startApp();
-                }, false);
-            }
-
-            console.assert(!(runningEmbedded && standAlone));
-            console.assert(runningEmbedded || standAlone);
-            console.log('Starting App' + (runningEmbedded ? ' embedded' : '') + (inFSL ? ' in FSL' : '') + (standAlone ? ' stand alone' : ''));
-        };
 
         function startApp() {
             // if launched from a record, this is the object Id in question

--- a/helloembed.html
+++ b/helloembed.html
@@ -107,13 +107,14 @@
        * ******************************/
       const runningEmbedded = (window.top !== window.self);
       window.onload = function() {
-
+        var inFSL = false;
+        var standAlone = false;
         if (runningEmbedded && window.parent.pulsar && window.parent.pulsar.bridge) {
           /* ************************************************************
-           * If the above is true, we are running in an embedded state
-           * within the Pulsar for FSL app. In this case, the above
-           * registered event listener will never fire as the webview we
-           * are running in already has established a Pulsar JS bridge.
+           * If the above is true, we are running in an embedded state.
+           * In this case, the above registered event listener will never
+           * fire as the webview we are running in already has
+           * established a Pulsar JS bridge.
            * ************************************************************/
           window.pulsar = window.parent.pulsar; // ensure we will pass down the embedded window.pulsar
           console.assert(window.pulsar.bridge !== undefined);
@@ -138,8 +139,12 @@
              * webview context. The Pulsar JS bridge will be established by
              * the event listener above. So we do nothing here.
              * ************************************************************/
+             standAlone = true;
           }
         }
+        console.assert(!(runningEmbedded && standAlone));
+        console.assert(runningEmbedded || standAlone);
+        console.log('Starting App' + (runningEmbedded ? ' embedded' : '') + (inFSL ? ' in FSL' : '') + (standAlone ? ' stand alone' : ''));
       };
       /* ******************************
        * END Pulsar onload definition

--- a/helloembed.html
+++ b/helloembed.html
@@ -7,83 +7,146 @@
     <title>Pulsar JS Hello World</title>
 
     <script type="text/javascript">
+      /* *********************************
+       * Prepare for bridge initialization
+       * *********************************/
 
-    /* ******************************
-     * BEGIN Pulsar bridge definition
-     * ******************************/
+      /* Launched from an unembedded state, startApp() fires on the bridge ready event. */
+      document.addEventListener('WebViewJavascriptBridgeReady', function(event) {
+        bridge.init(event.bridge);
 
-        var BRIDGE_ON = true; // set to false to test file in desktop browser
+        /* Note: If we are receiving this event, window.pulsar is undefined */
+        window.pulsar = {};
+        window.pulsar.bridge = event.bridge; // save initial bridge (for propagation to other pages)
 
-        var bridge = function() {
+        /* !!!! IMPORTANT !!!!
+         * The bridge has been initialized and your app is ready for launch.
+         * startApp() is any arbitrary method that a developer may define
+         * to start their application using the Pulsar JS bridge.
+         */
+        startApp();
+      }, false);
 
-            var jsbridge;
-            var _bridge = {};
+      /* ******************************
+       * BEGIN Pulsar bridge definition
+       * ******************************/
+      var BRIDGE_ON = true; // set to false to test file in desktop browser
 
-            /** **************************************************************
-             *  Sends a request (object containing type,
-             *  object, and data properties) across the JS Bridge,
-             *  and results are delivered to the callback function
-             *  @param {object} request data
-             *  @param {function} callback result function (called asynchronously)
-             * ***************************************************************/
-            _bridge.sendRequest = function(request, callbackFn) {
-                try {
-                    if (BRIDGE_ON) {
-                        jsbridge.send(request, callbackFn);
-                    } else {
-                        callbackFn({});
-                    }
-                } catch (err) {
-                    alert('Javascript-App bridge error: ' + err);
-                }
-            };
+      var bridge = function() {
 
-            /** **************************************************************
-             * Add a handler for a particular notification
-             * @param {string} handlerName name of notification
-             * @param {function} handlerFn function called for notification
-             * ***************************************************************/
-            _bridge.addHandler = function(handlerName, handlerFn) {
-                jsbridge.registerHandler(handlerName, handlerFn);
-            };
+        var jsbridge;
+        var _bridge = {};
 
-            /** **************************************************************
-             * Remove handler for a particular notification
-             * @param {string} handlerName name of notification
-             * ***************************************************************/
-            _bridge.removeHandler = function(handlerName) {
-                jsbridge.deregisterHandler(handlerName);
-            };
-
-            /** **************************************************************
-             * Initializes the JS Bridge.
-             * This should only be called once.
-             * @param {WebViewJavascriptBridge} _jsbridge the bridge
-             * ***************************************************************/
-            _bridge.init = function(_jsbridge) {
-                if (BRIDGE_ON) {
-                    _jsbridge.init(function(message, responseCallback) {
-                        console.log('Received message: ' + message);
-                    });
-
-                    jsbridge = _jsbridge;
-                }
-            };
-
-            /** **************************************************************
-             * Sets up JS Bridge without reinitializing.
-             * @param {WebViewJavascriptBridge} _jsbridge the bridge
-             * ***************************************************************/
-            _bridge.setup = function(_jsbridge) {
-                jsbridge = _jsbridge;
+        /** **************************************************************
+         *  Sends a request (object containing type,
+         *  object, and data properties) across the JS Bridge,
+         *  and results are delivered to the callback function
+         *  @param {object} request data
+         *  @param {function} callback result function (called asynchronously)
+         * ***************************************************************/
+        _bridge.sendRequest = function(request, callbackFn) {
+          try {
+            if (BRIDGE_ON) {
+              jsbridge.send(request, callbackFn);
+            } else {
+              callbackFn({});
             }
+          } catch (err) {
+            alert('Javascript-App bridge error: ' + err);
+          }
+        };
 
-            return _bridge;
-        }();
+        /** **************************************************************
+         * Add a handler for a particular notification
+         * @param {string} handlerName name of notification
+         * @param {function} handlerFn function called for notification
+         * ***************************************************************/
+        _bridge.addHandler = function(handlerName, handlerFn) {
+          jsbridge.registerHandler(handlerName, handlerFn);
+        };
 
-    /* ******************************
-     *  END Pulsar bridge definition
-     * ******************************/
+        /** **************************************************************
+         * Remove handler for a particular notification
+         * @param {string} handlerName name of notification
+         * ***************************************************************/
+        _bridge.removeHandler = function(handlerName) {
+          jsbridge.deregisterHandler(handlerName);
+        };
+
+        /** **************************************************************
+         * Initializes the JS Bridge.
+         * This should only be called once.
+         * @param {WebViewJavascriptBridge} _jsbridge the bridge
+         * ***************************************************************/
+        _bridge.init = function(_jsbridge) {
+          if (BRIDGE_ON) {
+            _jsbridge.init(function(message, responseCallback) {
+              console.log('Received message: ' + message);
+            });
+
+            jsbridge = _jsbridge;
+          }
+        };
+
+        /** **************************************************************
+         * Sets up JS Bridge without reinitializing.
+         * @param {WebViewJavascriptBridge} _jsbridge the bridge
+         * ***************************************************************/
+        _bridge.setup = function(_jsbridge) {
+          jsbridge = _jsbridge;
+        }
+
+        return _bridge;
+      }();
+      /* ******************************
+       *  END Pulsar bridge definition
+       * ******************************/
+
+      /* ******************************
+       * BEGIN Pulsar onload definition
+       * ******************************/
+      const runningEmbedded = (window.top !== window.self);
+      window.onload = function() {
+
+        if (runningEmbedded && window.parent.pulsar && window.parent.pulsar.bridge) {
+          /* ************************************************************
+           * If the above is true, we are running in an embedded state
+           * within the Pulsar for FSL app. In this case, the above
+           * registered event listener will never fire as the webview we
+           * are running in already has established a Pulsar JS bridge.
+           * ************************************************************/
+          window.pulsar = window.parent.pulsar; // ensure we will pass down the embedded window.pulsar
+          console.assert(window.pulsar.bridge !== undefined);
+          bridge.setup(window.pulsar.bridge);
+
+          /* At this point we have the correct Pulsar JS Bridge object from the window itself.
+           * Start your app! */
+          startApp();
+
+        } else {
+          if (runningEmbedded) {
+            /* ************************************************************
+             * Something has gone wrong if we are running embedded and find
+             * ourselves without a window.parent.pulsar.bridge or
+             * window.parent.pulsar object.
+             * ************************************************************/
+            console.log('OOPS, running embedded, but no window.parent.pulsar.bridge!');
+            throw 'embedded misconfiguration!';
+          } else {
+            /* ************************************************************
+             * Otherwise we are running in a stand-alone state in our own
+             * webview context. The Pulsar JS bridge will be established by
+             * the event listener above. So we do nothing here.
+             * ************************************************************/
+          }
+        }
+      };
+      /* ******************************
+       * END Pulsar onload definition
+       * ******************************/
+    </script>
+
+    <script type="text/javascript">
 
     /**
      * Helper function to extract URL query variables
@@ -195,39 +258,6 @@
         // example variables set during startup
         var platform = 'unknown';
         var refObjectId = undefined;
-
-        window.onload = function () {
-            let inFSL = false;
-            let standAlone = false;
-            const runningEmbedded = (window.top !== window.self);
-
-            if (runningEmbedded && window.parent.pulsar && window.parent.pulsar.bridge) {
-                window.pulsar = window.parent.pulsar; // ensure we will pass down the embedded window.pulsar
-                console.assert(window.pulsar.bridge !== undefined)
-                inFSL = (window.pulsar['displayContentDocument'] !== undefined); // FSL toplevel app sets additional methods you can use
-                bridge.setup(window.pulsar.bridge);
-                startApp();
-            }
-            else {
-                if (runningEmbedded) {
-                    console.log('OOPS, running embedded, but no window.parent.pulsar.bridge!');
-                    throw 'embedded misconfiguration!';
-                }
-                standAlone = true;
-
-                // Launched stand-alone, startApp() on the bridge ready event
-                document.addEventListener('WebViewJavascriptBridgeReady', function(event) {
-                    bridge.init(event.bridge);
-                    window.pulsar = {};
-                    window.pulsar.bridge = event.bridge; // save initial bridge (for propagation to other pages)
-                    startApp();
-                }, false);
-            }
-
-            console.assert(!(runningEmbedded && standAlone));
-            console.assert(runningEmbedded || standAlone);
-            console.log('Starting App' + (runningEmbedded ? ' embedded' : '') + (inFSL ? ' in FSL' : '') + (standAlone ? ' stand alone' : ''));
-        };
 
         function startApp() {
             // if launched from a record, this is the object Id in question

--- a/hellosync.html
+++ b/hellosync.html
@@ -7,83 +7,146 @@
     <title>Pulsar JS Hello World</title>
 
     <script type="text/javascript">
+      /* *********************************
+       * Prepare for bridge initialization
+       * *********************************/
 
-    /* ******************************
-     * BEGIN Pulsar bridge definition
-     * ******************************/
+      /* Launched from an unembedded state, startApp() fires on the bridge ready event. */
+      document.addEventListener('WebViewJavascriptBridgeReady', function(event) {
+        bridge.init(event.bridge);
 
-        var BRIDGE_ON = true; // set to false to test file in desktop browser
+        /* Note: If we are receiving this event, window.pulsar is undefined */
+        window.pulsar = {};
+        window.pulsar.bridge = event.bridge; // save initial bridge (for propagation to other pages)
 
-        var bridge = function() {
+        /* !!!! IMPORTANT !!!!
+         * The bridge has been initialized and your app is ready for launch.
+         * startApp() is any arbitrary method that a developer may define
+         * to start their application using the Pulsar JS bridge.
+         */
+        startApp();
+      }, false);
 
-            var jsbridge;
-            var _bridge = {};
+      /* ******************************
+       * BEGIN Pulsar bridge definition
+       * ******************************/
+      var BRIDGE_ON = true; // set to false to test file in desktop browser
 
-            /** **************************************************************
-             *  Sends a request (object containing type,
-             *  object, and data properties) across the JS Bridge,
-             *  and results are delivered to the callback function
-             *  @param {object} request data
-             *  @param {function} callback result function (called asynchronously)
-             * ***************************************************************/
-            _bridge.sendRequest = function(request, callbackFn) {
-                try {
-                    if (BRIDGE_ON) {
-                        jsbridge.send(request, callbackFn);
-                    } else {
-                        callbackFn({});
-                    }
-                } catch (err) {
-                    alert('Javascript-App bridge error: ' + err);
-                }
-            };
+      var bridge = function() {
 
-            /** **************************************************************
-             * Add a handler for a particular notification
-             * @param {string} handlerName name of notification
-             * @param {function} handlerFn function called for notification
-             * ***************************************************************/
-            _bridge.addHandler = function(handlerName, handlerFn) {
-                jsbridge.registerHandler(handlerName, handlerFn);
-            };
+        var jsbridge;
+        var _bridge = {};
 
-            /** **************************************************************
-             * Remove handler for a particular notification
-             * @param {string} handlerName name of notification
-             * ***************************************************************/
-            _bridge.removeHandler = function(handlerName) {
-                jsbridge.deregisterHandler(handlerName);
-            };
-
-            /** **************************************************************
-             * Initializes the JS Bridge.
-             * This should only be called once.
-             * @param {WebViewJavascriptBridge} _jsbridge the bridge
-             * ***************************************************************/
-            _bridge.init = function(_jsbridge) {
-                if (BRIDGE_ON) {
-                    _jsbridge.init(function(message, responseCallback) {
-                        console.log('Received message: ' + message);
-                    });
-
-                    jsbridge = _jsbridge;
-                }
-            };
-
-            /** **************************************************************
-             * Sets up JS Bridge without reinitializing.
-             * @param {WebViewJavascriptBridge} _jsbridge the bridge
-             * ***************************************************************/
-            _bridge.setup = function(_jsbridge) {
-                jsbridge = _jsbridge;
+        /** **************************************************************
+         *  Sends a request (object containing type,
+         *  object, and data properties) across the JS Bridge,
+         *  and results are delivered to the callback function
+         *  @param {object} request data
+         *  @param {function} callback result function (called asynchronously)
+         * ***************************************************************/
+        _bridge.sendRequest = function(request, callbackFn) {
+          try {
+            if (BRIDGE_ON) {
+              jsbridge.send(request, callbackFn);
+            } else {
+              callbackFn({});
             }
+          } catch (err) {
+            alert('Javascript-App bridge error: ' + err);
+          }
+        };
 
-            return _bridge;
-        }();
+        /** **************************************************************
+         * Add a handler for a particular notification
+         * @param {string} handlerName name of notification
+         * @param {function} handlerFn function called for notification
+         * ***************************************************************/
+        _bridge.addHandler = function(handlerName, handlerFn) {
+          jsbridge.registerHandler(handlerName, handlerFn);
+        };
 
-    /* ******************************
-     *  END Pulsar bridge definition
-     * ******************************/
+        /** **************************************************************
+         * Remove handler for a particular notification
+         * @param {string} handlerName name of notification
+         * ***************************************************************/
+        _bridge.removeHandler = function(handlerName) {
+          jsbridge.deregisterHandler(handlerName);
+        };
+
+        /** **************************************************************
+         * Initializes the JS Bridge.
+         * This should only be called once.
+         * @param {WebViewJavascriptBridge} _jsbridge the bridge
+         * ***************************************************************/
+        _bridge.init = function(_jsbridge) {
+          if (BRIDGE_ON) {
+            _jsbridge.init(function(message, responseCallback) {
+              console.log('Received message: ' + message);
+            });
+
+            jsbridge = _jsbridge;
+          }
+        };
+
+        /** **************************************************************
+         * Sets up JS Bridge without reinitializing.
+         * @param {WebViewJavascriptBridge} _jsbridge the bridge
+         * ***************************************************************/
+        _bridge.setup = function(_jsbridge) {
+          jsbridge = _jsbridge;
+        }
+
+        return _bridge;
+      }();
+      /* ******************************
+       *  END Pulsar bridge definition
+       * ******************************/
+
+      /* ******************************
+       * BEGIN Pulsar onload definition
+       * ******************************/
+      const runningEmbedded = (window.top !== window.self);
+      window.onload = function() {
+
+        if (runningEmbedded && window.parent.pulsar && window.parent.pulsar.bridge) {
+          /* ************************************************************
+           * If the above is true, we are running in an embedded state
+           * within the Pulsar for FSL app. In this case, the above
+           * registered event listener will never fire as the webview we
+           * are running in already has established a Pulsar JS bridge.
+           * ************************************************************/
+          window.pulsar = window.parent.pulsar; // ensure we will pass down the embedded window.pulsar
+          console.assert(window.pulsar.bridge !== undefined);
+          bridge.setup(window.pulsar.bridge);
+
+          /* At this point we have the correct Pulsar JS Bridge object from the window itself.
+           * Start your app! */
+          startApp();
+
+        } else {
+          if (runningEmbedded) {
+            /* ************************************************************
+             * Something has gone wrong if we are running embedded and find
+             * ourselves without a window.parent.pulsar.bridge or
+             * window.parent.pulsar object.
+             * ************************************************************/
+            console.log('OOPS, running embedded, but no window.parent.pulsar.bridge!');
+            throw 'embedded misconfiguration!';
+          } else {
+            /* ************************************************************
+             * Otherwise we are running in a stand-alone state in our own
+             * webview context. The Pulsar JS bridge will be established by
+             * the event listener above. So we do nothing here.
+             * ************************************************************/
+          }
+        }
+      };
+      /* ******************************
+       * END Pulsar onload definition
+       * ******************************/
+    </script>
+
+    <script type="text/javascript">
 
     /**
      * Helper function to extract URL query variables
@@ -129,40 +192,7 @@
 
         // example variables set during startup
         var platform = 'unknown';
-        var refObjectId = undefined;
-
-        window.onload = function () {
-            let inFSL = false;
-            let standAlone = false;
-            const runningEmbedded = (window.top !== window.self);
-
-            if (runningEmbedded && window.parent.pulsar && window.parent.pulsar.bridge) {
-                window.pulsar = window.parent.pulsar; // ensure we will pass down the embedded window.pulsar
-                console.assert(window.pulsar.bridge !== undefined)
-                inFSL = (window.pulsar['displayContentDocument'] !== undefined); // FSL toplevel app sets additional methods you can use
-                bridge.setup(window.pulsar.bridge);
-                startApp();
-            }
-            else {
-                if (runningEmbedded) {
-                    console.log('OOPS, running embedded, but no window.parent.pulsar.bridge!');
-                    throw 'embedded misconfiguration!';
-                }
-                standAlone = true;
-
-                // Launched stand-alone, startApp() on the bridge ready event
-                document.addEventListener('WebViewJavascriptBridgeReady', function(event) {
-                    bridge.init(event.bridge);
-                    window.pulsar = {};
-                    window.pulsar.bridge = event.bridge; // save initial bridge (for propagation to other pages)
-                    startApp();
-                }, false);
-            }
-
-            console.assert(!(runningEmbedded && standAlone));
-            console.assert(runningEmbedded || standAlone);
-            console.log('Starting App' + (runningEmbedded ? ' embedded' : '') + (inFSL ? ' in FSL' : '') + (standAlone ? ' stand alone' : ''));
-        };
+        var refObjectId = undefined;        
 
         function startApp() {
             // if launched from a record, this is the object Id in question

--- a/hellosync.html
+++ b/hellosync.html
@@ -107,13 +107,14 @@
        * ******************************/
       const runningEmbedded = (window.top !== window.self);
       window.onload = function() {
-
+        var inFSL = false;
+        var standAlone = false;
         if (runningEmbedded && window.parent.pulsar && window.parent.pulsar.bridge) {
           /* ************************************************************
-           * If the above is true, we are running in an embedded state
-           * within the Pulsar for FSL app. In this case, the above
-           * registered event listener will never fire as the webview we
-           * are running in already has established a Pulsar JS bridge.
+           * If the above is true, we are running in an embedded state.
+           * In this case, the above registered event listener will never
+           * fire as the webview we are running in already has
+           * established a Pulsar JS bridge.
            * ************************************************************/
           window.pulsar = window.parent.pulsar; // ensure we will pass down the embedded window.pulsar
           console.assert(window.pulsar.bridge !== undefined);
@@ -138,8 +139,12 @@
              * webview context. The Pulsar JS bridge will be established by
              * the event listener above. So we do nothing here.
              * ************************************************************/
+             standAlone = true;
           }
         }
+        console.assert(!(runningEmbedded && standAlone));
+        console.assert(runningEmbedded || standAlone);
+        console.log('Starting App' + (runningEmbedded ? ' embedded' : '') + (inFSL ? ' in FSL' : '') + (standAlone ? ' stand alone' : ''));
       };
       /* ******************************
        * END Pulsar onload definition
@@ -192,7 +197,7 @@
 
         // example variables set during startup
         var platform = 'unknown';
-        var refObjectId = undefined;        
+        var refObjectId = undefined;
 
         function startApp() {
             // if launched from a record, this is the object Id in question

--- a/pulsar-js-bridge.html
+++ b/pulsar-js-bridge.html
@@ -116,10 +116,10 @@
 
       if (runningEmbedded && window.parent.pulsar && window.parent.pulsar.bridge) {
         /* ************************************************************
-         * If the above is true, we are running in an embedded state
-         * within the Pulsar for FSL app. In this case, the above
-         * registered event listener will never fire as the webview we
-         * are running in already has established a Pulsar JS bridge.
+         * If the above is true, we are running in an embedded state.
+         * In this case, the above registered event listener will never
+         * fire as the webview we are running in already has
+         * established a Pulsar JS bridge.
          * ************************************************************/
         window.pulsar = window.parent.pulsar; // ensure we will pass down the embedded window.pulsar
         console.assert(window.pulsar.bridge !== undefined);

--- a/pulsar-js-bridge.html
+++ b/pulsar-js-bridge.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset='utf-8'>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+  <title>Pulsar JS Bridge</title>
+
+  <!-- ----------------------------------------------------------------
+  - The following script element contains the required code to setup
+  - the Pulsar JS Bridge from any valid context. Implement your own
+  - startApp method in another script
+  - ------------------------------------------------------------------>
+  <script type="text/javascript">
+    /* *********************************
+     * Prepare for bridge initialization
+     * *********************************/
+
+    /* Launched from an unembedded state, startApp() fires on the bridge ready event. */
+    document.addEventListener('WebViewJavascriptBridgeReady', function(event) {
+      bridge.init(event.bridge);
+
+      /* Note: If we are receiving this event, window.pulsar is undefined */
+      window.pulsar = {};
+      window.pulsar.bridge = event.bridge; // save initial bridge (for propagation to other pages)
+
+      /* !!!! IMPORTANT !!!!
+       * The bridge has been initialized and your app is ready for launch.
+       * startApp() is any arbitrary method that a developer may define
+       * to start their application using the Pulsar JS bridge.
+       */
+      startApp();
+    }, false);
+
+    /* ******************************
+     * BEGIN Pulsar bridge definition
+     * ******************************/
+    var BRIDGE_ON = true; // set to false to test file in desktop browser
+
+    var bridge = function() {
+
+      var jsbridge;
+      var _bridge = {};
+
+      /** **************************************************************
+       *  Sends a request (object containing type,
+       *  object, and data properties) across the JS Bridge,
+       *  and results are delivered to the callback function
+       *  @param {object} request data
+       *  @param {function} callback result function (called asynchronously)
+       * ***************************************************************/
+      _bridge.sendRequest = function(request, callbackFn) {
+        try {
+          if (BRIDGE_ON) {
+            jsbridge.send(request, callbackFn);
+          } else {
+            callbackFn({});
+          }
+        } catch (err) {
+          alert('Javascript-App bridge error: ' + err);
+        }
+      };
+
+      /** **************************************************************
+       * Add a handler for a particular notification
+       * @param {string} handlerName name of notification
+       * @param {function} handlerFn function called for notification
+       * ***************************************************************/
+      _bridge.addHandler = function(handlerName, handlerFn) {
+        jsbridge.registerHandler(handlerName, handlerFn);
+      };
+
+      /** **************************************************************
+       * Remove handler for a particular notification
+       * @param {string} handlerName name of notification
+       * ***************************************************************/
+      _bridge.removeHandler = function(handlerName) {
+        jsbridge.deregisterHandler(handlerName);
+      };
+
+      /** **************************************************************
+       * Initializes the JS Bridge.
+       * This should only be called once.
+       * @param {WebViewJavascriptBridge} _jsbridge the bridge
+       * ***************************************************************/
+      _bridge.init = function(_jsbridge) {
+        if (BRIDGE_ON) {
+          _jsbridge.init(function(message, responseCallback) {
+            console.log('Received message: ' + message);
+          });
+
+          jsbridge = _jsbridge;
+        }
+      };
+
+      /** **************************************************************
+       * Sets up JS Bridge without reinitializing.
+       * @param {WebViewJavascriptBridge} _jsbridge the bridge
+       * ***************************************************************/
+      _bridge.setup = function(_jsbridge) {
+        jsbridge = _jsbridge;
+      }
+
+      return _bridge;
+    }();
+    /* ******************************
+     *  END Pulsar bridge definition
+     * ******************************/
+
+    /* ******************************
+     * BEGIN Pulsar onload definition
+     * ******************************/
+    const runningEmbedded = (window.top !== window.self);
+    window.onload = function() {
+
+      if (runningEmbedded && window.parent.pulsar && window.parent.pulsar.bridge) {
+        /* ************************************************************
+         * If the above is true, we are running in an embedded state
+         * within the Pulsar for FSL app. In this case, the above
+         * registered event listener will never fire as the webview we
+         * are running in already has established a Pulsar JS bridge.
+         * ************************************************************/
+        window.pulsar = window.parent.pulsar; // ensure we will pass down the embedded window.pulsar
+        console.assert(window.pulsar.bridge !== undefined);
+        bridge.setup(window.pulsar.bridge);
+
+        /* At this point we have the correct Pulsar JS Bridge object from the window itself.
+         * Start your app! */
+        startApp();
+
+      } else {
+        if (runningEmbedded) {
+          /* ************************************************************
+           * Something has gone wrong if we are running embedded and find
+           * ourselves without a window.parent.pulsar.bridge or
+           * window.parent.pulsar object.
+           * ************************************************************/
+          console.log('OOPS, running embedded, but no window.parent.pulsar.bridge!');
+          throw 'embedded misconfiguration!';
+        } else {
+          /* ************************************************************
+           * Otherwise we are running in a stand-alone state in our own
+           * webview context. The Pulsar JS bridge will be established by
+           * the event listener above. So we do nothing here.
+           * ************************************************************/
+        }
+      }
+    };
+    /* ******************************
+     * END Pulsar onload definition
+     * ******************************/
+  </script>
+
+  <!-- ----------------------------------------------------------------
+  - The following script element contains sample code that a developer
+  - might write. This particular example simply reports the context in
+  - which the current Pulsar JS bridge is running. For other examples,
+  - visit: https://github.com/luminixinc/PulsarForSalesforceJSExamples
+  - ------------------------------------------------------------------>
+  <script type="text/javascript">
+    var inFSL = false;
+    var standAlone = false;
+
+    function getApplicationStatus() {
+
+      if (runningEmbedded && window.parent.pulsar && window.parent.pulsar.bridge) {
+        // FSL toplevel app sets additional methods you can use
+        inFSL = (window.pulsar['displayContentDocument'] !== undefined);
+      } else {
+        standAlone = true;
+      }
+    }
+
+    /* !!!! IMPORTANT !!!!
+     * Here we define a custom starting point for the app. This function is
+     * called above once we are certain that we have established a functional
+     * Pulsar JS bridge. */
+    function startApp() {
+
+      getApplicationStatus();
+
+      if (bridge) {
+        console.log('Application started; bridge initialized!');
+      } else {
+        console.log('Application started; bridge initialization failed!');
+      }
+      let textElement = document.getElementById("applicationStatus");
+      let messageString = 'Starting App' + (runningEmbedded ? ' embedded' : '') + (inFSL ? ' in FSL' : '') + (standAlone ? ' stand alone' : '');
+      textElement.innerHTML = messageString;
+    }
+  </script>
+
+</head>
+
+<body>
+  <div id="applicationStatus"></div>
+</body>
+
+</html>


### PR DESCRIPTION
* due to changes in iOS (WKWebView etc) we had to move the registration for the bridge ready message to before "onload". This ensures that we recieve the bridge ready message and can load the app accordingly.